### PR TITLE
ignore strats with zero debt

### DIFF
--- a/scripts/jobs/v2/05-harvest-v2-keep3r-job-work.ts
+++ b/scripts/jobs/v2/05-harvest-v2-keep3r-job-work.ts
@@ -113,6 +113,7 @@ function promptAndSubmit(): Promise<void | Error> {
           let totalAssets = strategy.vaultContract.callStatic.totalAssets();
           let actualRatio = params.totalDebt / totalAssets * 10000;
           if(actualRatio < 10){ // 0.1% in BPS
+            console.log('avoiding for zero debtRatio '+ strategy.address +' ...');
             continue; // Ignore strategies which have no debtRatio AND no actualRatio
           }
         }

--- a/scripts/jobs/v2/05-harvest-v2-keep3r-job-work.ts
+++ b/scripts/jobs/v2/05-harvest-v2-keep3r-job-work.ts
@@ -108,6 +108,14 @@ function promptAndSubmit(): Promise<void | Error> {
           strategy.address
         );
         strategy.lastReport = params.lastReport;
+        let debtRatio = params.debtRatio;
+        if(debtRatio == 0){
+          let totalAssets = strategy.vaultContract.callStatic.totalAssets();
+          let actualRatio = params.totalDebt / totalAssets * 10000;
+          if(actualRatio < 10){ // 0.1% in BPS
+            continue; // Ignore strategies which have no debtRatio AND no actualRatio
+          }
+        }
         const cooldownCompleted = strategy.lastReport.lt(
           now.sub(strategy.maxReportDelay)
         );


### PR DESCRIPTION
Curve and Convex strategies have debtRatios which change somewhat commonly. 
It would be a pain to individually manage adding/removing each of these strategies when their debtRatio hits 0 or is increased from zero to some higher value.

A more dynamic (easier-to-manage) solution would be for the manual harvest script to ignore harvesting the strategy when `debtRatio == 0`. We also add in a check against `actualRatio` here to still do a harvest in situations where `debtRatio` was recently set to 0, but no harvest made since to pay existing strategy debt back to the vault.